### PR TITLE
Removed reviewers field from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    # Add reviewers
-    reviewers:
-      - "grzanka"


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change removes the `reviewers` field, which previously assigned "grzanka" as a reviewer for updates.