### PR TITLE
Refactor release workflow for clarity and organization

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,12 +48,9 @@ jobs:
         echo "Refs to build: $BUILD_REFS"
         echo "BUILD_REFS=$BUILD_REFS" >> "$GITHUB_OUTPUT"
         echo "LATEST_TAG_NAME=$LATEST_TAG_NAME" >> "$GITHUB_OUTPUT"
-      shell: bash
 
     - name: Build documentation
-      run: |
-        sphinx-multiversion docs _build/html "${{ steps.get_build_refs.outputs.BUILD_REFS }}"
-      shell: bash
+      run: sphinx-multiversion docs _build/html ${{ steps.get_build_refs.outputs.BUILD_REFS }}
 
     - name: Copy latest release docs to 'latest' directory
       if: ${{ steps.get_build_refs.outputs.LATEST_TAG_NAME != '' }}
@@ -62,7 +59,6 @@ jobs:
         echo "Copying docs from '$LATEST_TAG_NAME' to 'latest/'"
         mkdir -p ./_build/html/latest/
         cp -r ./_build/html/"$LATEST_TAG_NAME"/. ./_build/html/latest/
-      shell: bash
 
     - name: Upload documentation artifacts
       uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
         echo "LATEST_TAG_NAME=$LATEST_TAG_NAME" >> "$GITHUB_OUTPUT"
 
     - name: Build documentation
-      run: sphinx-multiversion docs _build/html ${{ steps.get_build_refs.outputs.BUILD_REFS }}
+      run: sphinx-multiversion docs _build/html
 
     - name: Copy latest release docs to 'latest' directory
       if: ${{ steps.get_build_refs.outputs.LATEST_TAG_NAME != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install build, upload, and executable packaging tools
       run: |
-        python -m pip install setuptools build twine pyinstaller
+        python -m pip install --upgrade setuptools build twine pyinstaller
 
     - name: Build sdist and wheel distributions
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,19 +2,27 @@
 
 name: Release and Publish
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
+  workflow_dispatch:
+  push:
+    branches:
+     - master
   release:
-    types: [published] # This workflow triggers when a new GitHub Release is published
+    types:
+      - published
+  schedule:
+    - cron: '46 18 * * 2'
+
+env:
+  FORCE_COLOR: 3
 
 jobs:
-  build-and-publish:
+  build:
     runs-on: ubuntu-latest
-
-    environment: pypi
-
-    permissions:
-      id-token: write  # Required for OIDC authentication with PyPI (Trusted Publishing)
-      contents: write  # Required to upload assets (wheels/sdists/executables) to the GitHub Release
 
     steps:
     - name: Checkout code
@@ -22,22 +30,14 @@ jobs:
       with:
         fetch-depth: 0 # Important for setuptools_scm to get correct version from git tags
 
-    - name: Set up Python 3.12
-      # Use a specific, stable Python 3 version for consistent builds across all artifacts
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12' # Using 3.12 as per your primary dev version
+        python-version: '3.12'
 
     - name: Install build, upload, and executable packaging tools
       run: |
-        python -m pip install --upgrade setuptools
-        # Install tools for Python package distribution
-        pip install build twine
-        # Install tools for standalone executables
-        pip install pyinstaller # For PyInstaller executable
-        # Note: Nuitka typically has more complex setup, make_single_executable.sh handles its setup
-        # if make_single_executable.sh uses something other than 'build' for its internal wheel creation,
-        # ensure those dependencies are also installed here.
+        python -m pip install setuptools build twine pyinstaller
 
     - name: Build sdist and wheel distributions
       run: |
@@ -49,29 +49,47 @@ jobs:
 
     - name: Build PyInstaller Executable
       run: |
-        # Ensure 'main.spec' is in your project root or provide the correct path
         pyinstaller main.spec
-        ls -al dist/generatemc # Verify the executable is created by PyInstaller
+        ls -al dist/generatemc
 
-    - name: Build Zipapp Executable
-      run: |
-        chmod +x make_single_executable.sh # Make the script executable
-        # Run the script. It will build the wheel (if not already done by python -m build),
-        # create the zipapp, and test it internally.
-        ./make_single_executable.sh
-        ls -al generatemc.pyz # Verify the .pyz file was created
+    - uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: dist/*
+
+
+  publish:
+    name: Upload if release
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    environment: pypi
+    permissions:
+      id-token: write
+      attestations: write
+
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: packages
+        path: dist
+
+    - name: Generate artifact attestation for sdist and wheels
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: "dist/*whl"
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        attestations: true
 
     - name: Upload release assets to GitHub Release
       uses: softprops/action-gh-release@v2
-      if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-          dist/* # Includes your .whl and .tar.gz
-          generatemc.pyz       # Zipapp executable
-
-#    - name: Publish Python packages to PyPI
-#      # This is for your .whl and .tar.gz files only.
-#      uses: pypa/gh-action-pypi-publish@release/v1
-#      with:
-        # No need for PYPI_API_TOKEN secret with Trusted Publishing, as it uses OIDC
-        # repository-url: https://test.pypi.org/legacy/ # Uncomment to publish to TestPyPI for testing
+          dist/* # Includes your .whl and single executable files
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,14 @@ jobs:
 
   publish:
     name: Upload if release
-    needs: [build_wheels, build_sdist]
+    needs: [build]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     environment: pypi
     permissions:
       id-token: write
       attestations: write
+      contents: write
 
     steps:
     - uses: actions/setup-python@v5
@@ -90,6 +91,4 @@ jobs:
     - name: Upload release assets to GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        files: |
-          dist/* # Includes your .whl and single executable files
-          
+        files: dist/*


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for documentation and release processes. The changes streamline the workflows by simplifying commands, adding new triggers, and improving artifact handling. Below are the key changes grouped by theme:

### Documentation Workflow Updates
* Removed redundant `shell: bash` declarations and simplified the `Build documentation` step by reducing the multi-line command to a single line. (`.github/workflows/docs.yml`, [.github/workflows/docs.ymlL51-R53](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL51-R53))
* Removed `shell: bash` from the `Copy latest release docs to 'latest' directory` step for consistency and simplicity. (`.github/workflows/docs.yml`, [.github/workflows/docs.ymlL65](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL65))

### Release Workflow Enhancements
* Added `permissions` block to explicitly define access levels for `contents` and `pull-requests`. Introduced new triggers (`workflow_dispatch`, `push` to `master`, and a `cron` schedule) to increase flexibility in running the workflow. (`.github/workflows/release.yml`, [.github/workflows/release.ymlR5-R40](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R5-R40))
* Consolidated Python package installation commands into a single line for efficiency and removed unnecessary comments. (`.github/workflows/release.yml`, [.github/workflows/release.ymlR5-R40](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R5-R40))
* Reorganized the release workflow by splitting it into two jobs: `build` (for building artifacts) and `publish` (for uploading to PyPI and GitHub). Added artifact attestation for enhanced security and replaced manual artifact uploads with `actions/upload-artifact@v4`. (`.github/workflows/release.yml`, [.github/workflows/release.ymlL52-R94](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L52-R94))