### PR TITLE
Refactor release workflow: remove Python setup step and add upload re…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,13 +52,13 @@ jobs:
     - name: Build documentation
       run: sphinx-multiversion docs _build/html
 
-    - name: Copy latest release docs to 'latest' directory
-      if: ${{ steps.get_build_refs.outputs.LATEST_TAG_NAME != '' }}
-      run: |
-        LATEST_TAG_NAME="${{ steps.get_build_refs.outputs.LATEST_TAG_NAME }}"
-        echo "Copying docs from '$LATEST_TAG_NAME' to 'latest/'"
-        mkdir -p ./_build/html/latest/
-        cp -r ./_build/html/"$LATEST_TAG_NAME"/. ./_build/html/latest/
+    # - name: Copy latest release docs to 'latest' directory
+    #   if: ${{ steps.get_build_refs.outputs.LATEST_TAG_NAME != '' }}
+    #   run: |
+    #     LATEST_TAG_NAME="${{ steps.get_build_refs.outputs.LATEST_TAG_NAME }}"
+    #     echo "Copying docs from '$LATEST_TAG_NAME' to 'latest/'"
+    #     mkdir -p ./_build/html/latest/
+    #     cp -r ./_build/html/"$LATEST_TAG_NAME"/. ./_build/html/latest/
 
     - name: Upload documentation artifacts
       uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,14 +52,6 @@ jobs:
     - name: Build documentation
       run: sphinx-multiversion docs _build/html
 
-    # - name: Copy latest release docs to 'latest' directory
-    #   if: ${{ steps.get_build_refs.outputs.LATEST_TAG_NAME != '' }}
-    #   run: |
-    #     LATEST_TAG_NAME="${{ steps.get_build_refs.outputs.LATEST_TAG_NAME }}"
-    #     echo "Copying docs from '$LATEST_TAG_NAME' to 'latest/'"
-    #     mkdir -p ./_build/html/latest/
-    #     cp -r ./_build/html/"$LATEST_TAG_NAME"/. ./_build/html/latest/
-
     - name: Upload documentation artifacts
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,12 +84,7 @@ jobs:
       with:
         attestations: true
 
-    - name: Upload release assets to GitHub Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: dist/*
-
-  upload:
+  upload-release-assets:
     name: Upload if release
     needs: [build]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,6 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.x"
-
     - uses: actions/download-artifact@v4
       with:
         name: packages
@@ -87,6 +83,27 @@ jobs:
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:
         attestations: true
+
+    - name: Upload release assets to GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: dist/*
+
+  upload:
+    name: Upload if release
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: packages
+        path: dist
 
     - name: Upload release assets to GitHub Release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This pull request introduces changes to the GitHub Actions workflows to improve maintainability and add new functionality. The key changes include commenting out an unused step in the documentation workflow, removing an unnecessary setup step in the release workflow, and adding a new job to handle conditional release asset uploads.

### Documentation Workflow Updates:
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL55-R61): Commented out the step for copying the latest release documentation to the `latest` directory, as it is currently unused.

### Release Workflow Updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L73-L76): Removed the `actions/setup-python` step, as it is no longer required for the workflow.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R91-R111): Added a new `upload` job to conditionally upload release assets to GitHub Releases when a release is published. This job includes downloading artifacts and uploading them to the release.